### PR TITLE
symlink so dockerd can be found in both locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get -y install \
 RUN mkdir -p /root/.docker && \
     echo '{"credsStore": "ecr-login"}' > /root/.docker/config.json
 
+# Make a symlink for dockerd so it can be found by codebuild
+RUN ln -s /usr/bin/dockerd /usr/local/bin/dockerd
+
 # Add amazon-ecr-credential-helper to PATH
 ENV PATH="/usr/bin:$PATH"
 


### PR DESCRIPTION
When starting dockerd on AWS CodeBuild with Railpack, we look for it in `/usr/bin/dockerd`. On generic CodeBuild, we look for it in `/usr/local/bin/dockerd`. Creating a symlink ensures both can be accessed from the same path using the path AWS images uses. Creating a symlink is a better choice in case any old paths weren’t updated. This way, both paths remain valid, preserving backward compatibility.