### PR TITLE
codebuild needs jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -y update && \
     apt-transport-https \
     ca-certificates \
     curl \
+    jq \
     make \
     software-properties-common && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \


### PR DESCRIPTION
```
[Container] 2025/11/06 20:31:29.480398 Running command TOKEN_LINES=$(echo "https://public.ecr.aws" \| docker-credential-ecr-login get \| jq -j '"\(.Username):\(.Secret)"' \| base64 -w 1024)
--
/codebuild/output/tmp/script.sh: 4: jq: not found
```

Fixes this when we try to get ECR credentials 